### PR TITLE
Project Config errors with Log4j

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,8 +1,0 @@
-# Root logger option
-log4j.rootLogger=DEBUG, stdout
-
-# Redirect log messages to console
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,9 @@
+# Root logger level
+rootLogger.level = debug
+# Redirect log messages to console
+rootLogger.appenderRef.stdout.ref = consoleLogger
+
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
Project misconfiguration leads to log errors when compiling / executing tests.